### PR TITLE
tighten electron vertex cuts

### DIFF
--- a/src/EventTree.cxx
+++ b/src/EventTree.cxx
@@ -572,9 +572,10 @@ Bool_t EventTree::CheckVertex() {
 
   // electron Vz cuts
   if(RundepTorus(runnum)==kInbending) {
-    vzBoolEle = -13 < eleVertex[eZ] && eleVertex[eZ] < 12; // inbending
+    // vzBoolEle = -13 < eleVertex[eZ] && eleVertex[eZ] < 12; // inbending, RGA common cuts
+    vzBoolEle = -8.5 < eleVertex[eZ] && eleVertex[eZ] < 4.5; // inbending; tighter than RGA common cuts, to remove foil from RGB data
   } else {
-    vzBoolEle = -18 < eleVertex[eZ] && eleVertex[eZ] < 10; // outbending
+    vzBoolEle = -18 < eleVertex[eZ] && eleVertex[eZ] < 10; // outbending, RGA common cuts
   };
 
   // | had_Vz - ele_Vz | cut


### PR DESCRIPTION
this removes the target foil bump in the electron vertex distribution,
around vz=+6 cm