### PR TITLE
fix: torus for fiducial and vertex cuts on MC data

### DIFF
--- a/calcKinematics.cpp
+++ b/calcKinematics.cpp
@@ -373,7 +373,7 @@ int main(int argc, char** argv) {
 
     // fiducial cuts
     for(int p=0; p<nPar; p++) {
-      fidu[p]->ApplyCuts(runnum,(int)Pid[p]);
+      fidu[p]->ApplyCuts(runnum,(int)Pid[p],outrootDir);
     };
 
 

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -434,7 +434,8 @@ enum torus_enum {
   kInbending = -1,
   kOutbending = 1
 };
-static Int_t RundepTorus(Int_t run) {
+// get torus, given runnum; if MC the runnum is always 11, so use fileName instead
+static Int_t RundepTorus(Int_t run, TString fileName="") {
   if     (run>= 5032 && run<= 5419) return kInbending;  // rga_inbending_fa18
   else if(run>= 5422 && run<= 5666) return kOutbending; // rga_outbending_fa18
   else if(run>= 6616 && run<= 6783) return kInbending;  // rga_inbending_sp19
@@ -442,7 +443,14 @@ static Int_t RundepTorus(Int_t run) {
   else if(run>=11093 && run<=11283) return kOutbending; // rgb_outbending_fa19
   else if(run>=11284 && run<=11300) return kInbending;  // rgb_BAND_inbending_fa19
   else if(run>=11323 && run<=11571) return kInbending;  // rgb_inbending_wi20
-  else if(run==11) return kInbending; // MC for RGA inbending
+  else if(run==11) {
+    if(fileName.Contains("inbending")) return kInbending;
+    else if(fileName.Contains("outbending")) return kOutbending;
+    else {
+      fprintf(stderr,"ERROR: RundepTorus file name or path does not contain 'inbending' or 'outbending' (necessary if runnum==11)\n");
+      return kInbending;
+    }
+  }
   else {
     fprintf(stderr,"ERROR: RundepTorus unknown for run %d\n",run);
     return kInbending;

--- a/src/EventTree.cxx
+++ b/src/EventTree.cxx
@@ -5,11 +5,12 @@ ClassImp(EventTree)
 using namespace std;
 
 
-EventTree::EventTree(TString filelist, Int_t whichPair_) {
+EventTree::EventTree(TString filelist_, Int_t whichPair_) {
   printf("EventTree instantiated\n");
 
   debug = true;
 
+  filelist = filelist_;
   DecodePairType(whichPair_,whichHad[qA],whichHad[qB]);
   printf("\n>>> DIHADRON SELECTION: %s\n\n",PairName(whichHad[qA],whichHad[qB]).Data());
 
@@ -592,7 +593,7 @@ Float_t EventTree::Rellum() {
 Bool_t EventTree::CheckVertex() {
 
   // electron Vz cuts // tighter than RGA common cuts, to remove foil from Spring2019+ data
-  switch(RundepTorus(runnum)) {
+  switch(RundepTorus(runnum,filelist)) {
     case kInbending:  vzBoolEle = -8.0  < eleVertex[eZ] && eleVertex[eZ] < 3.0; break;
     case kOutbending: vzBoolEle = -10.0 < eleVertex[eZ] && eleVertex[eZ] < 2.5; break;
   };

--- a/src/EventTree.h
+++ b/src/EventTree.h
@@ -36,7 +36,7 @@ class EventTree : public TObject
 {
   public:
     EventTree() {};
-    EventTree(TString filelist, Int_t whichPair_=0x34);
+    EventTree(TString filelist_, Int_t whichPair_=0x34);
     ~EventTree();
 
     virtual void GetEvent(Long64_t i);
@@ -250,6 +250,7 @@ class EventTree : public TObject
 
   private:
     TChain * chain;
+    TString filelist;
     Int_t whichHad[2];
 
     Dihadron * objDihadron;

--- a/src/FiducialCuts.cxx
+++ b/src/FiducialCuts.cxx
@@ -20,10 +20,10 @@ FiducialCuts::FiducialCuts() {
 
 
 // apply the cuts; public booleans listed in header file will be set
-void FiducialCuts::ApplyCuts(int runnum_, int pid_) {
+void FiducialCuts::ApplyCuts(int runnum_, int pid_, TString fileName_) {
 
   // use runnumber to determine torus setting (Constants.h)
-  Int_t torus = RundepTorus(runnum_);
+  Int_t torus = RundepTorus(runnum_,fileName_);
   switch(torus) {
     case kInbending:
       inbending=true;

--- a/src/FiducialCuts.h
+++ b/src/FiducialCuts.h
@@ -28,7 +28,7 @@ class FiducialCuts : public TObject {
 
     // method which applies the cuts
     // - sets booleans listed below
-    void ApplyCuts(int runnum_, int pid_);
+    void ApplyCuts(int runnum_, int pid_, TString fileName_="");
     // - booleans (so far just one)
     Bool_t fiduCut;
 


### PR DESCRIPTION
close #42

MC always has `runnum` of `11`, so `RundepTorus` is no longer sufficient with `runnum` alone; this PR adds a workaround allowing the usage of file names to get the torus setting for MC data.