### PR TITLE
fix: Trento angles should use initial lepton momentum

### DIFF
--- a/src/Dihadron.cxx
+++ b/src/Dihadron.cxx
@@ -60,7 +60,7 @@ void Dihadron::CalculateKinematics(
 
   // get 3-momenta from 4-momenta
   pQ = disVecQ.Vect();
-  pL = disVecElectron.Vect();
+  pL = disVecBeam.Vect();
   pPh = vecPh.Vect();
   pR = vecR.Vect();
   for(h=0; h<2; h++) pHad[h] = vecHad[h].Vect();


### PR DESCRIPTION
...not the scattered lepton momentum.

This should not make any difference, since $\ell$, $\ell'$ and $q$ are all in the same plane.

Close #48 