### PR TITLE
build: support ROOT 6.26

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -18,7 +18,7 @@ FLAGS += -O0
 
 
 # ROOT
-#DEPS = $(shell root-config --cflags) # contains deprecated flags
+FLAGS += $(shell root-config --cflags)
 DEPS = -I$(shell root-config --incdir)
 LIBS = $(shell root-config --glibs)
 LIBS += -lMinuit -lRooFitCore -lRooFit -lRooStats -lProof -lMathMore

--- a/src/Asymmetry.h
+++ b/src/Asymmetry.h
@@ -45,7 +45,6 @@
 #include <RooAddPdf.h>
 #include <RooPlot.h>
 #include <RooNLLVar.h>
-#include <RooMinuit.h>
 
 
 // dispin


### PR DESCRIPTION
- update `brufit`
- build with C++ 17
- tested with 
```
  1) gcc/9.3.0           5) groovy/4.0.3        9) rcdb/0.06.00       13) ced/1.5.09
  2) cmake/3.25.0        6) python3/3.9.7      10) qadb/1.2.2         14) mcgen/2.23b
  3) maven/3.9.0         7) root/6.26.10       11) clas12root/1.8.0   15) paw/2005
  4) graalvm/22.2.0-17   8) ccdb/1.07.00       12) coatjava/9.0.0     16) clas12/pro
```

Brufit did not seem to work with root v6.28, specifically on `ifarm`, despite there being a `R6.28` branch in Derek's fork; so let's go with 6.26.
