### PR TITLE
feat: build an apptainer image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.exe
 *.o
 *.so
+*.sif
 .nfs*
 src/*.pcm
 *.root

--- a/image/build_image.sh
+++ b/image/build_image.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+apptainer build --fakeroot dispin.sif dispin.def

--- a/image/dispin.def
+++ b/image/dispin.def
@@ -1,0 +1,16 @@
+Bootstrap: docker
+From: rootproject/root:{{ VERSION }}-{{ OS }}
+Stage: build
+
+%labels
+    Author dilks
+
+%arguments
+    VERSION=6.26.10
+    OS=arch
+
+%post
+    ls
+
+%startscript
+    [ -f env.sh ] && source env.sh


### PR DESCRIPTION
To help keep this software stable and have better dependency control, this PR containerizes `dispin` dependencies in an Apptainer image. This will help ensure the analysis runs the same on any computer.