### PR TITLE
fix(build): `stringSpinSim.exe` shouldn't be a separate recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,25 +7,20 @@ DEPS += -Isrc
 
 
 # assume each .cpp file has main and build corresponding .exe executable
-# - omit any .cpp files which should be built with separate recipes
-SOURCES := $(filter-out stringSpinSim, $(basename $(wildcard *.cpp)))
+ifdef STRINGSPINNER
+	SOURCES := $(basename $(wildcard *.cpp))
+else
+	SOURCES := $(filter-out stringSpinSim, $(basename $(wildcard *.cpp)))
+endif
 EXES := $(addsuffix .exe, $(SOURCES))
 
-
 #--------------------------------------------
-
 
 all:
 	$(MAKE) -C src
 	make exe
 
 exe: $(EXES)
-
-stringSpinSim: DEPS += -I${PYTHIADIR}/include
-stringSpinSim: LIBS += -L${PYTHIADIR}/lib -lpythia8 -ldl
-stringSpinSim: DEPS += -I${STRINGSPINNER}
-stringSpinSim: LIBS += ${STRINGSPINNER}/mc3P0.o ${STRINGSPINNER}/def.o -lgfortran
-stringSpinSim: stringSpinSim.exe
 
 %.exe: %.o
 	@echo "--- make executable $@"

--- a/config.mk
+++ b/config.mk
@@ -30,6 +30,14 @@ LIBS += -L$(BRUFIT)/lib -lbrufit
 # QADB
 DEPS += -I$(QADB)/srcC/rapidjson/include -I$(QADB)/srcC/include
 
+# StringSpinner + Pythia 8
+ifdef STRINGSPINNER
+	DEPS += -I${PYTHIADIR}/include
+	LIBS += -L${PYTHIADIR}/lib -lpythia8 -ldl
+	DEPS += -I${STRINGSPINNER}
+	LIBS += ${STRINGSPINNER}/mc3P0.o ${STRINGSPINNER}/def.o -lgfortran
+endif
+
 # DiSpin shared object name and source directory
 DISPIN = DiSpin
 DISPINOBJ := lib$(DISPIN).so

--- a/doc/stringspinner.md
+++ b/doc/stringspinner.md
@@ -3,7 +3,7 @@
 Build:
 ```bash
 buildStringSpinner.sh
-make stringSpinSim
+make
 ```
 
 Make or symlink directories:

--- a/env.sh
+++ b/env.sh
@@ -3,7 +3,6 @@
 # software paths
 export DISPIN_HOME=$(dirname $(realpath $0))
 export BRUFIT=${DISPIN_HOME}/deps/brufit
-export STRINGSPINNER=${DISPIN_HOME}/deps/StringSpinner
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${BRUFIT}/lib
 
 # set dependency environment variables
@@ -22,7 +21,8 @@ popd
 # find pythia
 pythia_search=pythia8-config
 which $pythia_search &&
-  export PYTHIADIR=$(realpath $(dirname $(which $pythia_search))/..)
+  export PYTHIADIR=$(realpath $(dirname $(which $pythia_search))/..) &&
+  export STRINGSPINNER=${DISPIN_HOME}/deps/StringSpinner
 
 # print results
 echo ""
@@ -32,6 +32,7 @@ env|grep --color -w BRUFIT
 env|grep --color -w LD_LIBRARY_PATH
 env|grep --color -w JYPATH
 env|grep --color -w PYTHIADIR
+env|grep --color -w STRINGSPINNER
 echo "=============================="
 
 # checks

--- a/stringSpinSim.cpp
+++ b/stringSpinSim.cpp
@@ -4,8 +4,8 @@
 # include <vector>
 
 // pythia, stringspinner
-#include "Pythia8/Pythia.h"
-#include <StringSpinner.h>
+#include <Pythia8/Pythia.h>
+#include "deps/StringSpinner/StringSpinner.h"
 
 // ROOT
 #include <TFile.h>


### PR DESCRIPTION
`make stringSpinSim` can't find ROOT headers. No idea why, because the generated `g++` commands for `stringSpinSim` are effectively identical to those of all other executables.

So, instead use the existence of certain environment veriables to automatically decide whether or not `stringSpinSim.exe` should be built.