### PR TITLE
fix: `mcgen` stream issues with StringSpinner

### DIFF
--- a/doc/stringspinner.md
+++ b/doc/stringspinner.md
@@ -23,7 +23,7 @@ mv <output cattree file> catTrees/
 
 Compare kinematics
 ```bash
-root -b -q CompareCatTreeDists.C'("catTrees/catTreeData.sss.0x34.idx.root","catTrees/catTreeData.rga.pm.bibending.all.idx.root")'
+root -b -q CompareCatTreeDists.C'("catTrees/catTreeData.sss.0x34.idx.root","catTrees/catTreeData.mcgen.inbending.bg45.0x34.idx.root")'
 ```
 
 $M_h$ Decomposition

--- a/doc/stringspinner.md
+++ b/doc/stringspinner.md
@@ -10,7 +10,6 @@ Make or symlink directories:
 ```
 diskim.sss
 outroot.sss
-bruspin/bruspin.sss
 ```
 
 Generate `outroot` files, then the `catTree` (see settings in the script first):

--- a/loop_stringSpinSim.rb
+++ b/loop_stringSpinSim.rb
@@ -3,7 +3,7 @@
 
 # settings #################
 NumEventsPerFile = 5e6.to_i
-NumFiles         = 10
+NumFiles         = 60
 Modes            = [ 0, 1 ] # stringSpinSim.exe modes
 DiskimDir        = 'diskim.sss'
 OutrootDir       = 'outroot.sss'
@@ -59,6 +59,7 @@ NumFiles.times do |filenum|
         'calcKinematics.exe',
         diskimFile,
         OutrootDir,
+        'mcgen',
       ].join(' ')
     ].join(' && ')
     puts cmd


### PR DESCRIPTION
https://github.com/c-dilks/dispin/pull/59 implemented the `mcgen` stream, but it wasn't tested with StringSpinner. This PR fixes any issues with StringSpinner.