### PR TITLE
fix: don't re-run `calcKinematics` for radiative corrections

### DIFF
--- a/runDiskim.sh
+++ b/runDiskim.sh
@@ -25,17 +25,12 @@ if [ ! -d $outrootdir ]; then
   echo "ERROR: you must create or link outroot directory $outrootdir" >&2; exit 1;
 fi
 
-# check if running with radiative corrections
+# check if running with radiative corrections; if so, use `radroot` dir in place of `outroot` dir
 if [[ "$datastream" =~ rad$ ]]; then
-  useRad=1
-  radstream=$datastream
-  datastream=$(echo $radstream | sed 's/rad$//')
-  radrootdir=$(echo $outrootdir | sed 's/^outroot/radroot/')
-  if [ ! -d $radrootdir ]; then
-    echo "ERROR: you must create or link radroot directory $radrootdir" >&2; exit 1;
+  outrootdir=$(echo $outrootdir | sed 's/^outroot/radroot/')
+  if [ ! -d $outrootdir ]; then
+    echo "ERROR: you must create or link radroot directory $outrootdir" >&2; exit 1;
   fi
-else
-  useRad=0
 fi
 
 # produce (intermediate) diskim file
@@ -46,13 +41,6 @@ sleep 1
 # run calcKinematics
 calcKinematics.exe $diskimfile $outrootdir $datastream injgen
 sleep 1
-
-# if using radiative corrections, run calcKinematics a 2nd time,
-# with the RC-corrected beam energy model
-if [ $useRad = 1 ]; then
-  calcKinematics.exe $diskimfile $radrootdir $radstream injgen
-  sleep 1
-fi
 
 # cleanup intermediate diskim file
 rm -v $diskimfile

--- a/slurm.diskim.sh
+++ b/slurm.diskim.sh
@@ -14,7 +14,7 @@ if [ $# -lt 1 ];then
   echo "   $0 [train directory] [outroot dir] [datastream:data/mcrec/mcgen] [optional:skim/dst]"
   echo ""
   echo "      OPTIONS FOR SYSTEMATIC STUDIES:"
-  echo "      - append \"rad\" to the end of datastream to re-run calcKinematics with RC beam model"
+  echo "      - append \"rad\" to the end of datastream to run calcKinematics with RC beam model"
   echo "      - append \"positron\" to the end of datastream to reconstruct DIS kinematics with the POSITRON"
   exit 2
 fi


### PR DESCRIPTION
No need to reproduce more `outroot` files for `*rad` datastreams; we just need the `radroot` files.