### PR TITLE
feat: set helicity for outroot files

### DIFF
--- a/runDiskim.sh
+++ b/runDiskim.sh
@@ -2,7 +2,7 @@
 # produces `diskim` file, and subsequently, `outroot` file
 
 if [ $# -lt 1 ]; then
-  echo "USAGE: $0 [skim file] [optional:outrootDir] [optional:datastream=data/mcrec/mcgen] [optional:hipotype=skim/dst]"
+  echo "USAGE: $0 [skim file] [optional:outrootDir] [optional:datastream=data/mcrec/mcgen] [optional:hipotype=skim/dst] [optional:set_helicity]"
   echo "       you can also specify a directory of DST files, but you must also supply the \"dst\" hipotype argument"
   exit 2
 fi
@@ -10,9 +10,11 @@ skimfile=$1
 outrootdir="outroot"
 datastream="data"
 hipotype="skim"
+setHelicity=0
 if [ $# -ge 2 ]; then outrootdir="$2"; fi
 if [ $# -ge 3 ]; then datastream="$3"; fi
 if [ $# -ge 4 ]; then hipotype="$4"; fi
+if [ $# -ge 5 ]; then setHelicity=$5; fi
 
 # check setup
 if [ -z "$DISPIN_HOME" ]; then
@@ -35,7 +37,7 @@ fi
 
 # produce (intermediate) diskim file
 diskimfile="diskim/$(echo $skimfile|sed 's/^.*\///g').root"
-run-groovy skimDihadrons.groovy $skimfile $datastream $hipotype
+run-groovy skimDihadrons.groovy $skimfile $datastream $hipotype $setHelicity
 sleep 1
 
 # run calcKinematics

--- a/skimDihadrons.groovy
+++ b/skimDihadrons.groovy
@@ -21,9 +21,11 @@ import java.lang.Math.*
 def inHipoName = "../data/skim/skim4_005052.hipo" // skim file, or directory of DST files
 def dataStream = 'data' // 'data', 'mcrec', 'mcgen'
 def inHipoType = "skim" // options: "skim", "dst"
+def setHelicity = 0
 if(args.length>=1) inHipoName = args[0]
 if(args.length>=2) dataStream = args[1]
 if(args.length>=3) inHipoType = args[2]
+if(args.length>=4) setHelicity = args[3].toInteger()
 ////////////////////////
 // OPTIONS
 def verbose = 0
@@ -586,7 +588,7 @@ inHipoList.each { inHipoFile ->
 
 
       // get event-level information
-      helicity = eventBank.getByte('helicity',0)
+      helicity = setHelicity==0 ? eventBank.getByte('helicity',0) : setHelicity
       runnum   = configBank.getInt('run',0)
       evnum    = configBank.getInt('event',0)
       if(once) {


### PR DESCRIPTION
This may be used to set helicity for MC files from `clas-stringspinner` from OSG simulation jobs. Currently the output helicity is `0`, while the `clas-stringspinner` user sets the helicity.

This PR allows for the outroot files to have a custom helicity.